### PR TITLE
Changing default MySQL port to match default port chosen by DBInstanc…

### DIFF
--- a/rds/sc-rds-mysql-ra.json
+++ b/rds/sc-rds-mysql-ra.json
@@ -100,7 +100,7 @@
         "DBPortNumber": {
             "Description": "The port number on which the database accepts connections.",
             "Type": "Number",
-            "Default": "5432",
+            "Default": "3306",
             "MinValue": "1150",
             "MaxValue": "65535",
             "ConstraintDescription": "Valid values range from 1150-65535"

--- a/rds/sc-rds-mysql-ra.yml
+++ b/rds/sc-rds-mysql-ra.yml
@@ -78,7 +78,7 @@ Parameters:
   DBPortNumber:
     Description: The port number on which the database accepts connections.
     Type: Number
-    Default: '5432'
+    Default: '3306'
     MinValue: '1150'
     MaxValue: '65535'
     ConstraintDescription: Valid values range from 1150-65535


### PR DESCRIPTION
…e resource

*Issue #, if available:*

*Description of changes:*

The DBInstance resource in these templates is launched with a default port of 3306, but the PortNumber parameter defaults to the PostgreSQL default port.  This change updates the PortNumber parameter to match the parameter used by the DBInstance.

It may also make sense to pass the PortNumber parameter to the DBInstance, as it's currently just used for the security group.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
