### PR TITLE
updates for ITSM IAM handling

### DIFF
--- a/ec2/sc-portfolio-ec2.json
+++ b/ec2/sc-portfolio-ec2.json
@@ -124,7 +124,20 @@
             "TimeoutInMinutes" : 5
           }
         },        
-        "LinkEndusers":{
+        "LinkEndusersRole":{
+          "Type" : "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
+          "Properties" : {
+            "PrincipalARN" : 
+                {"Fn::If" : [
+                    "CondCreateEndUsers",
+                    {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserRoleArn"]},
+                    {"Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role/ServiceCatalogEndusers" }
+                ]},
+            "PortfolioId" : {"Ref":"SCEC2portfolio"},
+            "PrincipalType" : "IAM"
+          }
+        },        
+        "LinkEndusersGroup":{
           "Type" : "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
           "Properties" : {
             "PrincipalARN" : 
@@ -192,13 +205,17 @@
         }
     },
     "Outputs": {
+        "EndUserRoleArn":{
+          "Condition":"CondCreateEndUsers",
+          "Value": {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserRoleArn"]}
+        },
         "EndUserGroupArn":{
           "Condition":"CondCreateEndUsers",
           "Value": {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserGroupArn"]}
         },
-        "EndUserGroupName":{
+        "EndUserRoleName":{
           "Condition":"CondCreateEndUsers",
-          "Value": {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserGroupName"]}
+          "Value": {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserRoleName"]}
         },
         "LaunchConstraintRoleARN":{
           "Condition":"CreateLaunchConstraint",

--- a/ec2/sc-portfolio-ec2VPC.json
+++ b/ec2/sc-portfolio-ec2VPC.json
@@ -125,7 +125,20 @@
             "TimeoutInMinutes" : 5
           }
         },        
-        "LinkEndusers":{
+        "LinkEndusersRole":{
+          "Type" : "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
+          "Properties" : {
+            "PrincipalARN" : 
+                {"Fn::If" : [
+                    "CondCreateEndUsers",
+                    {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserRoleArn"]},
+                    {"Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role/ServiceCatalogEndusers" }
+                ]},
+            "PortfolioId" : {"Ref":"SCEC2portfolio"},
+            "PrincipalType" : "IAM"
+          }
+        },
+        "LinkEndusersGroup":{
           "Type" : "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
           "Properties" : {
             "PrincipalARN" : 

--- a/ec2/sc-portfolio-ec2demo.json
+++ b/ec2/sc-portfolio-ec2demo.json
@@ -213,9 +213,9 @@
           "Condition":"CondCreateEndUsers",
           "Value": {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserGroupArn"]}
         },
-		"EndUserRoleName":{
+		"EndUserGroupName":{
           "Condition":"CondCreateEndUsers",
-          "Value": {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserRoleName"]}
+          "Value": {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserGroupName"]}
         },		
         "LaunchConstraintRoleARN":{
           "Condition":"CreateLaunchConstraint",

--- a/ec2/sc-portfolio-ec2demo.json
+++ b/ec2/sc-portfolio-ec2demo.json
@@ -124,7 +124,20 @@
             "TimeoutInMinutes" : 5
           }
         },        
-        "LinkEndusers":{
+        "LinkEndusersRole":{
+          "Type" : "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
+          "Properties" : {
+            "PrincipalARN" : 
+                {"Fn::If" : [
+                    "CondCreateEndUsers",
+                    {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserRoleArn"]},
+                    {"Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role/ServiceCatalogEndusers" }
+                ]},
+            "PortfolioId" : {"Ref":"SCEC2portfolio"},
+            "PrincipalType" : "IAM"
+          }
+        },
+        "LinkEndusersGroup":{
           "Type" : "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
           "Properties" : {
             "PrincipalARN" : 
@@ -192,13 +205,17 @@
         }
     },
     "Outputs": {
-		"EndUserGroupArn":{
+		"EndUserRoleArn":{
+          "Condition":"CondCreateEndUsers",
+          "Value": {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserRoleArn"]}
+        },
+        "EndUserGroupArn":{
           "Condition":"CondCreateEndUsers",
           "Value": {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserGroupArn"]}
         },
-		"EndUserGroupName":{
+		"EndUserRoleName":{
           "Condition":"CondCreateEndUsers",
-          "Value": {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserGroupName"]}
+          "Value": {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserRoleName"]}
         },		
         "LaunchConstraintRoleARN":{
           "Condition":"CreateLaunchConstraint",

--- a/emr/sc-emr-ra.json
+++ b/emr/sc-emr-ra.json
@@ -72,8 +72,8 @@
         "MasterInstanceType": {
             "Description": "Select the master node instance type.",
             "Type": "String",
-            "Default": "m5.large",
-            "AllowedValues": [
+            "Default": "m5.xlarge",
+            "AllowedValues": [                
                 "m5.xlarge",
                 "m5.2xlarge",
                 "m5.4xlarge",
@@ -86,7 +86,7 @@
         "CoreInstanceType": {
             "Description": "Select the core node instance type.",
             "Type": "String",
-            "Default": "m5.large",
+            "Default": "m5.xlarge",
             "AllowedValues": [
                 "m5.xlarge",
                 "m5.2xlarge",

--- a/emr/sc-portfolio-emr.json
+++ b/emr/sc-portfolio-emr.json
@@ -119,7 +119,20 @@
             "TimeoutInMinutes" : 5
           }
         },        
-        "LinkEndusers":{
+        "LinkEndusersRole":{
+          "Type" : "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
+          "Properties" : {
+            "PrincipalARN" : 
+                {"Fn::If" : [
+                    "CondCreateEndUsers",
+                    {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserRoleArn"]},
+                    {"Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role/ServiceCatalogEndusers" }
+                ]},
+            "PortfolioId" : {"Ref":"SCEMRportfolio"},
+            "PrincipalType" : "IAM"
+          }
+        },
+        "LinkEndusersGroup":{
           "Type" : "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
           "Properties" : {
             "PrincipalARN" : 
@@ -139,8 +152,7 @@
             "TemplateURL" : {"Fn::Sub": "${RepoRootURL}iam/sc-emr-launchrole.yml"},
             "TimeoutInMinutes" : 5
           }
-        },
-        
+        },        
         "emrproduct": {
           "Type" : "AWS::CloudFormation::Stack",
           "Properties" : {

--- a/iam/SC-ITSM-demosetup.yml
+++ b/iam/SC-ITSM-demosetup.yml
@@ -50,6 +50,8 @@ Resources:
     DependsOn: SCPortfolioStack
     Properties:
       UserName: SCEndUser
+      Groups:
+        - !GetAtt SCPortfolioStack.Outputs.EndUserGroupName
       Policies:
         - PolicyName: StsAssumeSC        
           PolicyDocument:

--- a/iam/SC-ITSM-demosetup.yml
+++ b/iam/SC-ITSM-demosetup.yml
@@ -50,9 +50,16 @@ Resources:
     DependsOn: SCPortfolioStack
     Properties:
       UserName: SCEndUser
-      Groups:
-        - !GetAtt SCPortfolioStack.Outputs.EndUserGroupName
-                
+      Policies:
+        - PolicyName: StsAssumeSC        
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement: 
+              - Effect: "Allow"
+                Action: 
+                  - "sts:AssumeRole"
+                Resource: !GetAtt SCPortfolioStack.Outputs.EndUserRoleArn
+
   SCEndUserAccessKeys:
     DependsOn: SCEndUser
     Type: "AWS::IAM::AccessKey"

--- a/iam/sc-enduser-iam.yml
+++ b/iam/sc-enduser-iam.yml
@@ -6,7 +6,22 @@ Resources:
       GroupName: ServiceCatalogEndusers
       ManagedPolicyArns: 
         - arn:aws:iam::aws:policy/ServiceCatalogEndUserAccess
+      Path: /
+  SCEnduserRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: ServiceCatalogEndusers
+      ManagedPolicyArns: 
+        - arn:aws:iam::aws:policy/ServiceCatalogEndUserAccess
       Path: /      
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            Action:
+              - 'sts:AssumeRole'
   SCEnduserPolicy:
     Type: AWS::IAM::Policy
     Properties: 
@@ -24,12 +39,18 @@ Resources:
               - "cloudformation:ListStackResources"
             Resource: "*"
       PolicyName:  ServiceCatalogEndusers-AdditionalPermissions
+      Roles:
+        - !Ref SCEnduserRole
       Groups:
         - !Ref SCEnduserGroup
 Outputs:
     EndUserGroupArn:
         Value: !GetAtt SCEnduserGroup.Arn
     EndUserGroupName:
-        Value: !Ref SCEnduserGroup
+        Value: !Ref SCEnduserGroup        
+    EndUserRoleArn:
+        Value: !GetAtt SCEnduserRole.Arn
+    EndUserRoleName:
+        Value: !Ref SCEnduserRole
 
          

--- a/rds/sc-portfolio-rds.json
+++ b/rds/sc-portfolio-rds.json
@@ -119,7 +119,20 @@
             "TimeoutInMinutes" : 5
           }
         },        
-        "LinkEndusers":{
+        "LinkEndusersRole":{
+          "Type" : "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
+          "Properties" : {
+            "PrincipalARN" : 
+                {"Fn::If" : [
+                    "CondCreateEndUsers",
+                    {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserRoleArn"]},
+                    {"Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role/ServiceCatalogEndusers" }
+                ]},
+            "PortfolioId" : {"Ref":"SCRDSportfolio"},
+            "PrincipalType" : "IAM"
+          }
+        },
+        "LinkEndusersGroup":{
           "Type" : "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
           "Properties" : {
             "PrincipalARN" : 

--- a/s3/sc-portfolio-s3.json
+++ b/s3/sc-portfolio-s3.json
@@ -119,7 +119,20 @@
             "TimeoutInMinutes" : 5
           }
         },        
-        "LinkEndusers":{
+        "LinkEndusersRole":{
+          "Type" : "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
+          "Properties" : {
+            "PrincipalARN" : 
+                {"Fn::If" : [
+                    "CondCreateEndUsers",
+                    {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserRoleArn"]},
+                    {"Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role/ServiceCatalogEndusers" }
+                ]},
+            "PortfolioId" : {"Ref":"SCS3portfolio"},
+            "PrincipalType" : "IAM"
+          }
+        },
+        "LinkEndusersGroup":{
           "Type" : "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
           "Properties" : {
             "PrincipalARN" : 

--- a/templates/taskcat-verify-ec2VPC.json
+++ b/templates/taskcat-verify-ec2VPC.json
@@ -126,6 +126,14 @@
             "PrincipalType" : "IAM"
           }
         },
+        "LinkEndusers":{
+          "Type" : "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
+          "Properties" : {
+            "PrincipalARN" : {"Fn::GetAtt":["IAMenduser","Outputs.EndUserRoleArn"]},
+            "PortfolioId" : {"Ref":"SCEC2portfolio"},
+            "PrincipalType" : "IAM"
+          }
+        },
         "ec2linuxproduct": {
           "Type" : "AWS::CloudFormation::Stack",
           "Properties" : {

--- a/vpc/sc-portfolio-vpc.json
+++ b/vpc/sc-portfolio-vpc.json
@@ -118,7 +118,20 @@
             "TimeoutInMinutes" : 5
           }
         },        
-        "LinkEndusers":{
+        "LinkEndusersRole":{
+          "Type" : "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
+          "Properties" : {
+            "PrincipalARN" : 
+                {"Fn::If" : [
+                    "CondCreateEndUsers",
+                    {"Fn::GetAtt":["stackServiceCatalogEndusers","Outputs.EndUserRoleArn"]},
+                    {"Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role/ServiceCatalogEndusers" }
+                ]},
+            "PortfolioId" : {"Ref":"SCVPCportfolio"},
+            "PrincipalType" : "IAM"
+          }
+        },
+        "LinkEndusersGroup":{
           "Type" : "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
           "Properties" : {
             "PrincipalARN" : 


### PR DESCRIPTION
*Issue #, if available:*
Connector apps need both group and roles depending on design. The enduser group is still needed for pure AWS SC implementations for IAM user inheritance.

*Description of changes:*
SCEnduser is both a member of the group and may assume the role.  this way any connector can implement the IAM permissions as needed.  

also includes changes from PR #23 
