### PR TITLE
update sc-enduser-iam.yml. ServiceCatalogEndUserAccess policy is depr…

### DIFF
--- a/iam/sc-enduser-iam.yml
+++ b/iam/sc-enduser-iam.yml
@@ -5,14 +5,14 @@ Resources:
     Properties:
       GroupName: ServiceCatalogEndusers
       ManagedPolicyArns: 
-        - arn:aws:iam::aws:policy/ServiceCatalogEndUserAccess
+        - arn:aws:iam::aws:policy/AWSServiceCatalogEndUserFullAccess
       Path: /
   SCEnduserRole:
     Type: AWS::IAM::Role
     Properties:
       RoleName: ServiceCatalogEndusers
       ManagedPolicyArns: 
-        - arn:aws:iam::aws:policy/ServiceCatalogEndUserAccess
+        - arn:aws:iam::aws:policy/AWSServiceCatalogEndUserFullAccess
       Path: /      
       AssumeRolePolicyDocument:
         Version: 2012-10-17


### PR DESCRIPTION
…ecated and appears to have been replaced with arn:aws:iam::aws:policy/AWSServiceCatalogEndUserFullAccess

*Issue 
arn:aws:iam::aws:policy/ServiceCatalogEndUserAccess does not exist or is not attachable. (Service: AmazonIdentityManagement; Status Code: 404; Error Code: NoSuchEntity)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
