### PR TITLE
Update sc-enduser-iam.yml

### DIFF
--- a/iam/sc-enduser-iam.yml
+++ b/iam/sc-enduser-iam.yml
@@ -5,14 +5,14 @@ Resources:
     Properties:
       GroupName: ServiceCatalogEndusers
       ManagedPolicyArns: 
-        - arn:aws:iam::aws:policy/ServiceCatalogEndUserAccess
+        - arn:aws:iam::aws:policy/AWSServiceCatalogEndUserFullAccess
       Path: /
   SCEnduserRole:
     Type: AWS::IAM::Role
     Properties:
       RoleName: ServiceCatalogEndusers
       ManagedPolicyArns: 
-        - arn:aws:iam::aws:policy/ServiceCatalogEndUserAccess
+        - arn:aws:iam::aws:policy/AWSServiceCatalogEndUserFullAccess
       Path: /      
       AssumeRolePolicyDocument:
         Version: 2012-10-17


### PR DESCRIPTION
The stack fails because cannot find the managed policy ServiceCatalogEndUserAccess, there is no policy with this name. I tested with AWSServiceCatalogEndUserFullAccess and It worked. Could you check If the template should use AWSServiceCatalogEndUserFullAccess? Thank you!

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
