### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/serverless/sc-provision-serverless.yml
+++ b/serverless/sc-provision-serverless.yml
@@ -30,7 +30,7 @@ Parameters:
     - nodejs
     - nodejs4.3
     - nodejs6.10
-    - nodejs8.10
+    - nodejs10.x
     - nodejs4.3-edge
     - java8
     - python2.7

--- a/serverless/sc-serverless-lambda.yml
+++ b/serverless/sc-serverless-lambda.yml
@@ -23,7 +23,7 @@ Parameters:
     - nodejs
     - nodejs4.3
     - nodejs6.10
-    - nodejs8.10
+    - nodejs10.x
     - nodejs4.3-edge
     - java8
     - python2.7


### PR DESCRIPTION
CloudFormation templates in aws-service-catalog-reference-architectures have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.