### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/serverless/sc-provision-serverless.yml
+++ b/serverless/sc-provision-serverless.yml
@@ -29,7 +29,7 @@ Parameters:
     AllowedValues:
     - nodejs
     - nodejs4.3
-    - nodejs6.10
+    - nodejs10.x
     - nodejs8.10
     - nodejs4.3-edge
     - java8

--- a/serverless/sc-serverless-lambda.yml
+++ b/serverless/sc-serverless-lambda.yml
@@ -22,7 +22,7 @@ Parameters:
     AllowedValues:
     - nodejs
     - nodejs4.3
-    - nodejs6.10
+    - nodejs10.x
     - nodejs8.10
     - nodejs4.3-edge
     - java8


### PR DESCRIPTION
CloudFormation templates in aws-service-catalog-reference-architectures have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.