### PR TITLE
Add reference architecture for DynamoDB Table

### DIFF
--- a/dynamodb/README.md
+++ b/dynamodb/README.md
@@ -1,0 +1,24 @@
+# AWS Service Catalog DynamoDB Reference architecture
+
+This reference architecture creates an AWS Service Catalog Portfolio called
+ "AWS Service Catalog DynamoDB Reference Architecture" with 1 associated product.
+ The AWS Service Catalog Product references DynamoDB Table cloudformation template
+ which can be launched by end users through AWS Service Catalog.
+
+### Install  
+Launch the DynamoDB portfolio stack:  
+[![CreateStack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=SC-RA-DynamoDBPortfolio&templateURL=https://s3.amazonaws.com/aws-service-catalog-reference-architectures/dynamodb/sc-portfolio-dynamodb.yml)
+
+
+### Install from your own S3 bucket  
+1. clone this git repo:  
+  ```git clone git@github.com:aws-samples/aws-service-catalog-reference-architectures.git```  
+2. Copy everything in the repo to an S3 bucket:  
+  ```cd aws-service-catalog-reference-architectures```  
+  ```aws s3 cp . s3://[YOUR-BUCKET-NAME-HERE] --exclude "*" --include "*.json" --include "*.yml" --recursive```  
+3. In the AWS [CloudFormation console](https://console.aws.amazon.com/cloudformation) choose "Create Stack" and supply the Portfolio S3 url:  
+  ```https://s3.amazonaws.com/[YOUR-BUCKET-NAME-HERE]/dynamodb/sc-portfolio-dynamodb.yml```  
+5. Set the _LinkedRole1_ parameter to any additional end user role you may want to link to the Portfolio.
+6. Set the _CreateEndUsers_ parameter to No if you have already run a Portfolio stack from this repo (ServiceCatalogEndusers already exists).
+7. Change the _RepoRootURL_ parameter to your bucket's root url:  
+  ```https://s3.amazonaws.com/[YOUR-BUCKET-NAME-HERE]/``` 

--- a/dynamodb/sc-dynamodb-ra.yml
+++ b/dynamodb/sc-dynamodb-ra.yml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: "Service Catalog: DynamoDB Table Reference Architecture Template. This template builds an AWS DynamoDB table."
+Description: "Service Catalog: DynamoDB Table Reference Architecture Template. This template builds an AWS DynamoDB table. (fdp-1qj64b3i8)"
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -51,21 +51,23 @@ Parameters:
     MaxValue: 10000
     ConstraintDescription: must be between 5 and 10000
   PartitionKey:
-    Description: "REQUIRED: The name of the partition key for the table"
+    Description: "The name of the partition key for the table"
     Type: String
   PartitionKeyType:
     Description: "The data type of the partition key"
     Type: String
+    Default: String
     AllowedValues:
       - String
       - Number
       - Binary
   SortKey:
-    Description: "OPTIONAL: The name of the sort key for the table"
+    Description: "The name of the sort key for the table"
     Type: String
   SortKeyType:
     Description: "The data type of the sort key"
     Type: String
+    Default: String
     AllowedValues:
       - String
       - Number

--- a/dynamodb/sc-portfolio-dynamodb.yml
+++ b/dynamodb/sc-portfolio-dynamodb.yml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: DynamoDB Portfolio for Service Catalog.
+Description: DynamoDB Portfolio for Service Catalog. (fdp-1qj64b3hb)
 
 Parameters:
   PortfolioProvider:
@@ -31,7 +31,7 @@ Parameters:
     AllowedValues:
       - Yes
       - No
-    Default: Yes
+    Default: No
 
 Conditions:
   CreateLaunchConstraint: !Equals [!Ref LaunchRoleName, ""]
@@ -66,21 +66,17 @@ Resources:
 
   LinkEndusersRole:
     Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
+    Condition: CondCreateEndUsersGroup
     Properties:
-      PrincipalARN: !If
-        - CondCreateEndUsersGroup
-        - !GetAtt ["StackServiceCatalogEndusers", "Outputs.EndUserRoleArn"]
-        - !Sub arn:aws:iam::${AWS::AccountId}:role/SCEndUserRole
+      PrincipalARN: !GetAtt ["StackServiceCatalogEndusers", "Outputs.EndUserRoleArn"]
       PortfolioId: !Ref SCDynamoDBportfolio
       PrincipalType: IAM
 
   LinkEndusersGroup:
     Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
+    Condition: CondCreateEndUsersGroup
     Properties:
-      PrincipalARN: !If
-        - CondCreateEndUsersGroup
-        - !GetAtt ["StackServiceCatalogEndusers", "Outputs.EndUserGroupArn"]
-        - !Sub arn:aws:iam::${AWS::AccountId}:group/SCEndUserGroup
+      PrincipalARN: !GetAtt ["StackServiceCatalogEndusers", "Outputs.EndUserGroupArn"]
       PortfolioId: !Ref SCDynamoDBportfolio
       PrincipalType: "IAM"
 

--- a/dynamodb/sc-portfolio-dynamodb.yml
+++ b/dynamodb/sc-portfolio-dynamodb.yml
@@ -1,0 +1,106 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: DynamoDB Portfolio for Service Catalog.
+
+Parameters:
+  PortfolioProvider:
+    Type: String
+    Description: Provider Name
+    Default: IT Services
+  PortfolioName:
+    Type: String
+    Description: Portfolio Name
+    Default: Service Catalog DynamoDB Reference Architecture
+  PortfolioDescription:
+    Type: String
+    Description: Portfolio Description
+    Default: Service Catalog Portfolio that contains products for Amazon DynamoDB
+  LaunchRoleName:
+    Type: String
+    Description: Name of the launch constraint role for DynamoDB products. leave this blank to create the role
+  LinkedRole:
+    Type: String
+    Description: (Optional) The name of a role which can execute products in this portfolio
+  RepoRootURL:
+    Type: String
+    Description: Root url for the repo containing the product templates
+    Default: https://s3.amazonaws.com/aws-service-catalog-reference-architectures/
+  CreateEndUsersGroup:
+    Type: String
+    Description: Select Yes to Create the ServiceCatalogEndusers IAM group. No if you have already created the group
+    AllowedValues:
+      - Yes
+      - No
+    Default: Yes
+
+Conditions:
+  CreateLaunchConstraint: !Equals [!Ref LaunchRoleName, ""]
+  CondLinkRole: !Not
+    - !Equals [!Ref LinkedRole, ""]
+  CondCreateEndUsersGroup: !Equals
+    - !Ref CreateEndUsersGroup
+    - Yes
+
+Resources:
+  SCDynamoDBportfolio:
+    Type: AWS::ServiceCatalog::Portfolio
+    Properties:
+      ProviderName: !Ref PortfolioProvider
+      Description: !Ref PortfolioDescription
+      DisplayName: !Ref PortfolioName
+
+  Addrole:
+    Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
+    Condition: CondLinkRole
+    Properties:
+      PrincipalARN: !Sub arn:aws:iam::${AWS::AccountId}:role/${LinkedRole}
+      PortfolioId: !Ref SCDynamoDBportfolio
+      PrincipalType: IAM
+
+  StackServiceCatalogEndusers:
+    Type: AWS::CloudFormation::Stack
+    Condition: CondCreateEndUsersGroup
+    Properties:
+      TemplateURL: !Sub ${RepoRootURL}iam/sc-enduser-iam.yml
+      TimeoutInMinutes: 5
+
+  LinkEndusersRole:
+    Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
+    Properties:
+      PrincipalARN: !If
+        - CondCreateEndUsersGroup
+        - !GetAtt ["StackServiceCatalogEndusers", "Outputs.EndUserRoleArn"]
+        - !Sub arn:aws:iam::${AWS::AccountId}:role/SCEndUserRole
+      PortfolioId: !Ref SCDynamoDBportfolio
+      PrincipalType: IAM
+
+  LinkEndusersGroup:
+    Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation
+    Properties:
+      PrincipalARN: !If
+        - CondCreateEndUsersGroup
+        - !GetAtt ["StackServiceCatalogEndusers", "Outputs.EndUserGroupArn"]
+        - !Sub arn:aws:iam::${AWS::AccountId}:group/SCEndUserGroup
+      PortfolioId: !Ref SCDynamoDBportfolio
+      PrincipalType: "IAM"
+
+  LaunchConstraintRole:
+    Type: AWS::CloudFormation::Stack
+    Condition: CreateLaunchConstraint
+    Properties:
+      TemplateURL: !Sub ${RepoRootURL}iam/sc-dynamodb-launchrole.yml
+      TimeoutInMinutes: 5
+
+  DynamoDBStandardProduct:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Parameters:
+        PortfolioProvider: !Ref PortfolioProvider
+        LaunchConstraintARN: !If
+          - CreateLaunchConstraint
+          - !GetAtt ["LaunchConstraintRole", "Outputs.LaunchRoleArn"]
+          - !Sub arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}
+        PortfolioId: !Ref SCDynamoDBportfolio
+        RepoRootURL: !Ref RepoRootURL
+      TemplateURL: !Sub ${RepoRootURL}dynamodb/sc-product-dynamodb.yml
+      TimeoutInMinutes: 5

--- a/dynamodb/sc-product-dynamodb-ra.yml
+++ b/dynamodb/sc-product-dynamodb-ra.yml
@@ -31,7 +31,7 @@ Metadata:
 
 Parameters:
   TableName:
-    Description: "A name for the table. If you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the table name"
+    Description: "REQUIRED: A name for the table"
     Type: String
     MinLength: 3
     MaxLength: 255
@@ -121,7 +121,6 @@ Mappings:
       Binary: B
 
 Conditions:
-  TableNameProvided: !Not [!Equals [!Ref TableName, ""]]
   EnableStream: !Not [!Equals [!Ref StreamViewType, "DISABLED"]]
   EnableDataPlaneLogging: !Equals [!Ref EnableDataPlaneLogging, "true"]
   KMSMasterKeyIdProvided: !Not [!Equals [!Ref KMSMasterKeyId, ""]]
@@ -145,7 +144,7 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: !Ref ReadCapacityUnits
         WriteCapacityUnits: !Ref WriteCapacityUnits
-      TableName: !If [TableNameProvided, !Ref TableName, !Ref "AWS::NoValue"]
+      TableName: !Ref TableName
       SSESpecification:
         KMSMasterKeyId:
           !If [

--- a/dynamodb/sc-product-dynamodb-ra.yml
+++ b/dynamodb/sc-product-dynamodb-ra.yml
@@ -1,0 +1,190 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: "Service Catalog: DynamoDB Table Reference Architecture Template. This template builds an AWS DynamoDB table."
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Primary Key
+        Parameters:
+          - PartitionKey
+          - PartitionKeyType
+          - SortKey
+          - SortKeyType
+      - Label:
+          default: DynamoDB Table Configuration
+        Parameters:
+          - TableName
+          - ReadCapacityUnits
+          - WriteCapacityUnits
+          - KMSMasterKeyId
+          - PointInTimeRecoveryEnabled
+          - StreamViewType
+      - Label:
+          default: Logging Configuration
+        Parameters:
+          - EnableDataPlaneLogging
+          - TrailS3BucketName
+          - TrailS3KeyPrefix
+          - TrailEventsType
+
+Parameters:
+  TableName:
+    Description: "A name for the table. If you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the table name"
+    Type: String
+    MinLength: 3
+    MaxLength: 255
+    AllowedPattern: "[a-zA-Z0-9_.-]+"
+  ReadCapacityUnits:
+    Description: "The desired minimum number of consistent reads"
+    Type: Number
+    Default: 5
+    MinValue: 5
+    MaxValue: 10000
+    ConstraintDescription: must be between 5 and 10000
+  WriteCapacityUnits:
+    Description: "The desired minimum number of consistent writes"
+    Type: Number
+    Default: 5
+    MinValue: 5
+    MaxValue: 10000
+    ConstraintDescription: must be between 5 and 10000
+  PartitionKey:
+    Description: "REQUIRED: The name of the partition key for the table"
+    Type: String
+  PartitionKeyType:
+    Description: "The data type of the partition key"
+    Type: String
+    AllowedValues:
+      - String
+      - Number
+      - Binary
+  SortKey:
+    Description: "OPTIONAL: The name of the sort key for the table"
+    Type: String
+  SortKeyType:
+    Description: "The data type of the sort key"
+    Type: String
+    AllowedValues:
+      - String
+      - Number
+      - Binary
+  KMSMasterKeyId:
+    Description: "The AWS KMS customer master key (CMK) that should be used for the AWS KMS encryption. To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name, or alias ARN. Note that you should only provide this parameter if the key is different from the default DynamoDB customer master key alias/aws/dynamodb"
+    Type: String
+  StreamViewType:
+    Description: "When an item in the table is modified, StreamViewType determines what information is written to the stream for this table"
+    Type: String
+    Default: DISABLED
+    AllowedValues:
+      - DISABLED
+      - KEYS_ONLY
+      - NEW_IMAGE
+      - OLD_IMAGE
+      - NEW_AND_OLD_IMAGES
+  PointInTimeRecoveryEnabled:
+    Description: "Should the point in time recovery be enabled (true) or disabled (false) on the table?"
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+  EnableDataPlaneLogging:
+    Description: "Should the CloudTrail logs for data-plane operations be captured?"
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+  TrailS3BucketName:
+    Description: "The name of the Amazon S3 bucket designated for publishing log files"
+    Type: String
+    ConstraintDescription: "must be an existing Amazon S3 bucket"
+  TrailS3KeyPrefix:
+    Description: "The Amazon S3 key prefix that comes after the name of the bucket designated for log file delivery"
+    Type: String
+  TrailEventsType:
+    Description: "Specify if you want your trail to log read-only events, write-only events, or all"
+    Type: String
+    AllowedValues:
+      - All
+      - ReadOnly
+      - WriteOnly
+    Default: All
+
+Mappings:
+  AttributeTypeMap:
+    DataType:
+      String: S
+      Number: N
+      Binary: B
+
+Conditions:
+  TableNameProvided: !Not [!Equals [!Ref TableName, ""]]
+  EnableStream: !Not [!Equals [!Ref StreamViewType, "DISABLED"]]
+  EnableDataPlaneLogging: !Equals [!Ref EnableDataPlaneLogging, "true"]
+  KMSMasterKeyIdProvided: !Not [!Equals [!Ref KMSMasterKeyId, ""]]
+
+Resources:
+  StandardDynamoDBTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: !Ref PartitionKey
+          AttributeType:
+            !FindInMap [AttributeTypeMap, DataType, !Ref PartitionKeyType]
+        - AttributeName: !Ref SortKey
+          AttributeType:
+            !FindInMap [AttributeTypeMap, DataType, !Ref SortKeyType]
+      KeySchema:
+        - AttributeName: !Ref PartitionKey
+          KeyType: HASH
+        - AttributeName: !Ref SortKey
+          KeyType: RANGE
+      ProvisionedThroughput:
+        ReadCapacityUnits: !Ref ReadCapacityUnits
+        WriteCapacityUnits: !Ref WriteCapacityUnits
+      TableName: !If [TableNameProvided, !Ref TableName, !Ref "AWS::NoValue"]
+      SSESpecification:
+        KMSMasterKeyId:
+          !If [
+            KMSMasterKeyIdProvided,
+            !Ref KMSMasterKeyId,
+            "alias/aws/dynamodb",
+          ]
+        SSEEnabled: true
+        SSEType: KMS
+      StreamSpecification:
+        !If [
+          EnableStream,
+          StreamViewType: !Ref StreamViewType,
+          !Ref "AWS::NoValue",
+        ]
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: !Ref PointInTimeRecoveryEnabled
+
+  StandardDynamoDBCloudTrail:
+    Type: AWS::CloudTrail::Trail
+    Condition: EnableDataPlaneLogging
+    Properties:
+      IsLogging: true
+      S3BucketName: !Ref TrailS3BucketName
+      S3KeyPrefix: !Ref TrailS3KeyPrefix
+      EventSelectors:
+        - IncludeManagementEvents: false
+          DataResources:
+            - Type: AWS::DynamoDB::Table
+              Values:
+                - !GetAtt StandardDynamoDBTable.Arn
+          ReadWriteType: !Ref TrailEventsType
+
+Outputs:
+  DynamoDB:
+    Value: !Ref StandardDynamoDBTable
+    Export:
+      Name: !Sub ${AWS::StackName}-DynamoDB
+  DynamoDBArn:
+    Value: !GetAtt StandardDynamoDBTable.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-DynamoDBArn

--- a/dynamodb/sc-product-dynamodb.yml
+++ b/dynamodb/sc-product-dynamodb.yml
@@ -1,0 +1,50 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: Service Catalog DynamoDB Product
+
+Parameters:
+  PortfolioProvider:
+    Type: String
+    Description: Owner and Distributor Name
+  LaunchConstraintARN:
+    Type: String
+    Description: ARN of the launch constraint role for DynamoDB products
+  PortfolioId:
+    Type: String
+    Description: The ServiceCatalog portfolio this product will be attached to
+  RepoRootURL:
+    Type: String
+    Description: Root url for the repo containing the product templates
+
+Resources:
+  SCDynamoDBproduct:
+    Type: AWS::ServiceCatalog::CloudFormationProduct
+    Properties:
+      Name: Amazon DynamoDB Table
+      Description: This product builds an Amazon DynamoDB table
+      Owner: !Ref PortfolioProvider
+      Distributor: !Ref PortfolioProvider
+      SupportDescription: Operations Team
+      SupportEmail: support@yourcompany.com
+      AcceptLanguage: en
+      SupportUrl: http://helpdesk.yourcompany.com
+      ProvisioningArtifactParameters:
+        - Description: baseline version
+          Info:
+            LoadTemplateFromURL: !Sub ${RepoRootURL}dynamodb/sc-product-dynamodb-ra.yml
+          Name: v1.0
+
+  AssociateDynamoDB:
+    Type: AWS::ServiceCatalog::PortfolioProductAssociation
+    Properties:
+      PortfolioId: !Ref PortfolioId
+      ProductId: !Ref SCDynamoDBproduct
+
+  ConstraintDynamoDB:
+    Type: AWS::ServiceCatalog::LaunchRoleConstraint
+    DependsOn: AssociateDynamoDB
+    Properties:
+      PortfolioId: !Ref PortfolioId
+      ProductId: !Ref SCDynamoDBproduct
+      RoleArn: !Ref LaunchConstraintARN
+      Description: !Ref LaunchConstraintARN

--- a/dynamodb/sc-product-dynamodb.yml
+++ b/dynamodb/sc-product-dynamodb.yml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: Service Catalog DynamoDB Product
+Description: Service Catalog DynamoDB Product (fdp-1qj64b3i0)
 
 Parameters:
   PortfolioProvider:
@@ -31,7 +31,7 @@ Resources:
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
-            LoadTemplateFromURL: !Sub ${RepoRootURL}dynamodb/sc-product-dynamodb-ra.yml
+            LoadTemplateFromURL: !Sub ${RepoRootURL}dynamodb/sc-dynamodb-ra.yml
           Name: v1.0
 
   AssociateDynamoDB:

--- a/iam/sc-dynamodb-launchrole.yml
+++ b/iam/sc-dynamodb-launchrole.yml
@@ -1,0 +1,94 @@
+Description: "ServiceCatalog DynamoDB Launch Role"
+
+Resources:
+  SCDynamoDBLaunchRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: SCDynamoDBLaunchRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - servicecatalog.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+      Path: /
+      Policies:
+        - PolicyName: SCLaunchPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: CloudTrailAccess
+                Effect: Allow
+                Action:
+                  - cloudtrail:CreateTrail
+                  - cloudtrail:StartLogging
+                  - cloudtrail:DeleteTrail
+                  - cloudtrail:PutEventSelectors
+                  - cloudtrail:UpdateTrail
+                Resource: "*"
+              - Sid: KMSKeyAccess
+                Effect: Allow
+                Action:
+                  - kms:Encrypt
+                  - kms:Decrypt
+                  - kms:ReEncrypt*
+                  - kms:GenerateDataKey*
+                  - kms:DescribeKey
+                  - kms:CreateGrant
+                Resource: "*"
+              - Sid: ServiceCatalogAccess
+                Effect: Allow
+                Action:
+                  - "servicecatalog:ListServiceActionsForProvisioningArtifact"
+                  - "servicecatalog:ExecuteprovisionedProductServiceAction"
+                Resource: "*"
+              - Sid: IamAccess
+                Effect: Allow
+                Action:
+                  - "iam:AddRoleToInstanceProfile"
+                  - "iam:ListRolePolicies"
+                  - "iam:ListPolicies"
+                  - "iam:DeleteRole"
+                  - "iam:GetRole"
+                  - "iam:CreateInstanceProfile"
+                  - "iam:PassRole"
+                  - "iam:DeleteInstanceProfile"
+                  - "iam:ListRoles"
+                  - "iam:RemoveRoleFromInstanceProfile"
+                  - "iam:CreateRole"
+                  - "iam:DetachRolePolicy"
+                  - "iam:AttachRolePolicy"
+                Resource: "*"
+              - Sid: CloudformationAccess
+                Effect: Allow
+                Action:
+                  - "cloudformation:DescribeStackResource"
+                  - "cloudformation:DescribeStackResources"
+                  - "cloudformation:GetTemplate"
+                  - "cloudformation:List*"
+                  - "cloudformation:DescribeStackEvents"
+                  - "cloudformation:DescribeStacks"
+                  - "cloudformation:CreateStack"
+                  - "cloudformation:DeleteStack"
+                  - "cloudformation:DescribeStackEvents"
+                  - "cloudformation:DescribeStacks"
+                  - "cloudformation:GetTemplateSummary"
+                  - "cloudformation:SetStackPolicy"
+                  - "cloudformation:ValidateTemplate"
+                  - "cloudformation:UpdateStack"
+                Resource: "*"
+              - Sid: S3GetAccess
+                Effect: Allow
+                Action:
+                  - "s3:GetObject"
+                Resource: "*"
+Outputs:
+  LaunchRoleArn:
+    Value: !GetAtt SCDynamoDBLaunchRole.Arn
+  LaunchRoleName:
+    Value: !Ref SCDynamoDBLaunchRole

--- a/iam/sc-dynamodb-launchrole.yml
+++ b/iam/sc-dynamodb-launchrole.yml
@@ -1,4 +1,4 @@
-Description: "ServiceCatalog DynamoDB Launch Role"
+Description: "ServiceCatalog DynamoDB Launch Role (fdp-1qj64b3ik)"
 
 Resources:
   SCDynamoDBLaunchRole:


### PR DESCRIPTION
# Description
This pull request creates an AWS Service Catalog Portfolio called "AWS Service Catalog DynamoDB Reference Architecture" with 1 associated product. The AWS Service Catalog Product references DynamoDB Table CloudFormation template which can be launched by end users through AWS Service Catalog.
 ## Checklist

- An AWS Service Catalog Portfolio for DynamoDB products is created
- An AWS Service Catalog Product for DynamoDB table is created
- An AWS IAM Role associated with the Service Catalog Portfolio launch constraint is created 