### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/serverless/sc-provision-serverless.yml
+++ b/serverless/sc-provision-serverless.yml
@@ -28,7 +28,7 @@ Parameters:
     Default: python3.7
     AllowedValues:
     - nodejs12.x
-    - nodejs10.x    
+    - nodejs14.x    
     - java8
     - java11
     - python2.7

--- a/serverless/sc-serverless-lambda.yml
+++ b/serverless/sc-serverless-lambda.yml
@@ -21,7 +21,7 @@ Parameters:
     Default: python3.7
     AllowedValues:
     - nodejs12.x
-    - nodejs10.x    
+    - nodejs14.x    
     - java8
     - java11
     - python2.7


### PR DESCRIPTION
CloudFormation templates in aws-service-catalog-reference-architectures have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.