### PR TITLE
Update managed policy name for CodeCommit to fix breaking change

### DIFF
--- a/codepipeline/sc-codepipeline-ra.json
+++ b/codepipeline/sc-codepipeline-ra.json
@@ -92,7 +92,7 @@
                     "arn:aws:iam::aws:policy/AWSServiceCatalogAdminFullAccess",
                     "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
                     "arn:aws:iam::aws:policy/AmazonSSMFullAccess",
-                    "arn:aws:iam::aws:policy/AWSCodePipelineFullAccess"
+                    "arn:aws:iam::aws:policy/AWSCodePipeline_FullAccess"
                 ],
                 "Policies": [ { 
                     "PolicyName":"CodeBuildManageS3Artifacts",

--- a/ecs/container-codepipeline-ra.json
+++ b/ecs/container-codepipeline-ra.json
@@ -62,7 +62,7 @@
                 },
                 "ManagedPolicyArns": [
                     "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
-                    "arn:aws:iam::aws:policy/AWSCodePipelineFullAccess"
+                    "arn:aws:iam::aws:policy/AWSCodePipeline_FullAccess"
                 ],
                 "Policies": [ { 
                     "PolicyName":"CodeBuildManageS3Artifacts",

--- a/elasticbeanstalk/beanstalk-codepipeline-dotnet.json
+++ b/elasticbeanstalk/beanstalk-codepipeline-dotnet.json
@@ -56,7 +56,7 @@
                 },
                 "ManagedPolicyArns": [
                     "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
-                    "arn:aws:iam::aws:policy/AWSCodePipelineFullAccess",
+                    "arn:aws:iam::aws:policy/AWSCodePipeline_FullAccess",
 					"arn:aws:iam::aws:policy/AWSElasticBeanstalkFullAccess"
                 ],
                 "Policies": [ { 

--- a/elasticbeanstalk/beanstalk-codepipeline-ra.json
+++ b/elasticbeanstalk/beanstalk-codepipeline-ra.json
@@ -56,7 +56,7 @@
                 },
                 "ManagedPolicyArns": [
                     "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
-                    "arn:aws:iam::aws:policy/AWSCodePipelineFullAccess",
+                    "arn:aws:iam::aws:policy/AWSCodePipeline_FullAccess",
 					"arn:aws:iam::aws:policy/AWSElasticBeanstalkFullAccess"
                 ],
                 "Policies": [ { 

--- a/iam/sc-ecs-launchrole.yml
+++ b/iam/sc-ecs-launchrole.yml
@@ -7,7 +7,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonEC2FullAccess
         - arn:aws:iam::aws:policy/AWSCodeDeployFullAccess
-        - arn:aws:iam::aws:policy/AWSCodePipelineFullAccess
+        - arn:aws:iam::aws:policy/AWSCodePipeline_FullAccess
         - arn:aws:iam::aws:policy/AWSCodeCommitFullAccess
         - arn:aws:iam::aws:policy/AWSCodeBuildAdminAccess
         - arn:aws:iam::aws:policy/AmazonS3FullAccess

--- a/iam/sc-elasticbeanstalk-launchrole.yml
+++ b/iam/sc-elasticbeanstalk-launchrole.yml
@@ -7,7 +7,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AWSElasticBeanstalkFullAccess
         - arn:aws:iam::aws:policy/AWSCodeDeployFullAccess
-        - arn:aws:iam::aws:policy/AWSCodePipelineFullAccess
+        - arn:aws:iam::aws:policy/AWSCodePipeline_FullAccess
         - arn:aws:iam::aws:policy/AWSCodeCommitFullAccess
         - arn:aws:iam::aws:policy/AWSCodeBuildAdminAccess
         - arn:aws:iam::aws:policy/AmazonS3FullAccess


### PR DESCRIPTION
**Issue #:** https://github.com/aws-samples/aws-service-catalog-reference-architectures/issues/115 

**Description of changes:**
Update managed policy name from 'AWSCodePipelineFullAccess' to 'AWSCdePipeline_FullAccess'

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
