### PR TITLE
Upgrade GuardDuty lambda Python to 3.10

### DIFF
--- a/security/guardduty/deploy_guardduty.yml
+++ b/security/guardduty/deploy_guardduty.yml
@@ -96,7 +96,7 @@ Resources:
       Code: 
         S3Bucket: !Ref S3SourceBucket
         S3Key: !Ref S3Key
-      Runtime: "python3.8"
+      Runtime: "python3.10"
       MemorySize: 128
       Timeout: 600
       Environment:


### PR DESCRIPTION
*Issue #, if available:*

https://endoflife.date/aws-lambda

*Description of changes:*

Change Python 3.8 to 3.10

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
